### PR TITLE
Do power reset on machine deletion, not cycle.

### DIFF
--- a/internal/bmc/nsq.go
+++ b/internal/bmc/nsq.go
@@ -86,7 +86,7 @@ func (b *BMCService) InitConsumer() error {
 					if err != nil {
 						return err
 					}
-					return outBand.PowerReset()
+					return outBand.PowerCycle()
 				case ChassisIdentifyLEDOnCmd:
 					return outBand.IdentifyLEDOn()
 				case ChassisIdentifyLEDOffCmd:

--- a/internal/bmc/nsq.go
+++ b/internal/bmc/nsq.go
@@ -64,7 +64,7 @@ func (b *BMCService) InitConsumer() error {
 				if err != nil {
 					return err
 				}
-				return outBand.PowerCycle()
+				return outBand.PowerReset()
 			case Command:
 				switch event.Cmd.Command {
 				case MachineOnCmd:


### PR DESCRIPTION
We don't need a graceful shutdown here, which delays the machine going back into our pool.