### PR TITLE
Report powersupply status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.23
 require (
 	github.com/gliderlabs/ssh v0.3.7
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/metal-stack/go-hal v0.5.4
-	github.com/metal-stack/metal-go v0.35.2
+	github.com/metal-stack/go-hal v0.5.5-0.20240930121737-4436f2bc9418
+	github.com/metal-stack/metal-go v0.37.1-0.20241001061321-b6fa718f2176
 	github.com/metal-stack/v v1.0.3
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -80,10 +80,10 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/metal-stack/go-hal v0.5.4 h1:lovOdnYtcQnO81xEhmrrFuRonpZEauePTttA3ki0lSw=
-github.com/metal-stack/go-hal v0.5.4/go.mod h1:2yeab7N8ApBd44z7mEwWCb+CL7o3ioZu41kSsra50Dw=
-github.com/metal-stack/metal-go v0.35.2 h1:brTbmPUiYSH9IdbnCkrcRWFRlIfc0H/53f2phsB+5kY=
-github.com/metal-stack/metal-go v0.35.2/go.mod h1:3MJTYCS4YJz8D8oteTKhjpaAKNMMjMKYDrIy9awHGtQ=
+github.com/metal-stack/go-hal v0.5.5-0.20240930121737-4436f2bc9418 h1:6/ZxmMCAfsYB1lVDDGxn8w6MMcfdEkDHP/XRA4RpAls=
+github.com/metal-stack/go-hal v0.5.5-0.20240930121737-4436f2bc9418/go.mod h1:2yeab7N8ApBd44z7mEwWCb+CL7o3ioZu41kSsra50Dw=
+github.com/metal-stack/metal-go v0.37.1-0.20241001061321-b6fa718f2176 h1:QRHcudgrKQtVzyVFlsyjkJO9EQwUM0/dhbOs6PhSNaw=
+github.com/metal-stack/metal-go v0.37.1-0.20241001061321-b6fa718f2176/go.mod h1:MQN5ni2Gzu+x2sdk8blbh7elQD1W1vaf0E+RkiV2aoo=
 github.com/metal-stack/metal-lib v0.18.3 h1:bovFiJPB9SMvuGLqcXVWz6jFB8HrdzwnCX7TFlen4r0=
 github.com/metal-stack/metal-lib v0.18.3/go.mod h1:Ctyi6zaXFr2NVrQZLFsDLnFCzupKnYErTtgRFKAsnbw=
 github.com/metal-stack/security v0.8.1 h1:4zmVUxZvDWShVvVIxM3XhIv7pTmPe9DvACRIHW6YTsk=

--- a/internal/leases/bmc.go
+++ b/internal/leases/bmc.go
@@ -50,6 +50,16 @@ func (i *ReportItem) EnrichWithBMCDetails(ipmiPort int, ipmiUser, ipmiPassword s
 				Minconsumedwatts:     &board.PowerMetric.MinConsumedWatts,
 			}
 		}
+		var powerSupplies []*models.V1PowerSupply
+		for _, ps := range i.PowerSupplies {
+			powerSupplies = append(powerSupplies, &models.V1PowerSupply{
+				Status: &models.V1PowerSupplyStatus{
+					Health: ps.Status.Health,
+					State:  ps.Status.State,
+				},
+			})
+		}
+		i.PowerSupplies = powerSupplies
 	}
 
 	u, err := ob.UUID()

--- a/internal/leases/types.go
+++ b/internal/leases/types.go
@@ -18,12 +18,13 @@ type Leases []Lease
 
 type ReportItem struct {
 	Lease
-	Log          *slog.Logger
-	UUID         *string
-	BmcVersion   *string
-	BiosVersion  *string
-	FRU          *models.V1MachineFru
-	Powerstate   *string
-	IndicatorLED *string
-	PowerMetric  *models.V1PowerMetric
+	Log           *slog.Logger
+	UUID          *string
+	BmcVersion    *string
+	BiosVersion   *string
+	FRU           *models.V1MachineFru
+	Powerstate    *string
+	IndicatorLED  *string
+	PowerMetric   *models.V1PowerMetric
+	PowerSupplies []*models.V1PowerSupply
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -155,6 +155,7 @@ func (r reporter) report(items []*leases.ReportItem) error {
 			PowerState:        item.Powerstate,
 			IndicatorLEDState: item.IndicatorLED,
 			PowerMetric:       item.PowerMetric,
+			PowerSupplies:     item.PowerSupplies,
 		}
 		reports[*item.UUID] = report
 	}


### PR DESCRIPTION
## References

Closes #69

Depends on:

- [ ] https://github.com/metal-stack/go-hal/pull/66
- [ ] https://github.com/metal-stack/metal-api/pull/578

## Additional Description

Allow metal-bmc to report the state and health of the powersupplies of a machine.
