### PR TITLE
Require TLS peer cert to match machineID on console SSH

### DIFF
--- a/internal/bmc/console.go
+++ b/internal/bmc/console.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +23,11 @@ import (
 	"github.com/gliderlabs/ssh"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+// tlsPeerCertContextKey is the ssh.Context key under which the verified TLS
+// peer certificate is stashed by the ConnCallback. Using a pointer to a local
+// unexported type follows the gliderlabs/ssh convention for context keys.
+var tlsPeerCertContextKey = &struct{ name string }{name: "tls-peer-cert"}
 
 type console struct {
 	log       *slog.Logger
@@ -71,9 +78,18 @@ func NewConsole(log *slog.Logger, client metalgo.Client, c config.Config) (*cons
 }
 
 // ListenAndServe starts ssh server and listen for console connections.
+//
+// Trust model: every connection is wrapped in mTLS
+// (tls.RequireAndVerifyClientCert). The verified TLS peer certificate — not
+// the SSH username — is the only identity we trust. The SSH layer therefore
+// intentionally has no PublicKey/Password/KeyboardInteractive handler; the
+// gliderlabs/ssh server sets NoClientAuth=true in that case. Authorization
+// is performed in sessionHandler by matching the requested machineID against
+// the peer certificate (CN / DNS SAN).
 func (c *console) ListenAndServe() error {
 	s := &ssh.Server{
-		Handler: c.sessionHandler,
+		Handler:      c.sessionHandler,
+		ConnCallback: c.captureTLSPeerCert,
 	}
 	s.AddHostKey(c.hostKey)
 	addr := fmt.Sprintf(":%d", c.port)
@@ -85,10 +101,75 @@ func (c *console) ListenAndServe() error {
 	return s.Serve(listener)
 }
 
+// captureTLSPeerCert forces the TLS handshake to complete before any SSH
+// bytes flow and stashes the verified client leaf certificate on the SSH
+// context. Returning nil causes the connection to be closed.
+func (c *console) captureTLSPeerCert(ctx ssh.Context, conn net.Conn) net.Conn {
+	tc, ok := conn.(*tls.Conn)
+	if !ok {
+		c.log.Warn("refusing non-TLS connection to console server",
+			"remote", conn.RemoteAddr().String())
+		return nil
+	}
+	if err := tc.HandshakeContext(ctx); err != nil {
+		c.log.Warn("TLS handshake failed",
+			"remote", conn.RemoteAddr().String(), "error", err)
+		return nil
+	}
+	certs := tc.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		// Should be unreachable because tlsConfig uses
+		// RequireAndVerifyClientCert, but fail closed anyway.
+		c.log.Warn("no TLS peer certificate after handshake; rejecting",
+			"remote", conn.RemoteAddr().String())
+		return nil
+	}
+	ctx.SetValue(tlsPeerCertContextKey, certs[0])
+	return conn
+}
+
+// certAuthorizedFor reports whether the leaf client certificate is authorized
+// to open a console session for machineID. A machineID matches if it equals
+// the certificate's Subject CommonName or appears as a DNS SAN. This assumes
+// the console CA issues per-machine (or machine-listing) client certificates.
+func certAuthorizedFor(cert *x509.Certificate, machineID string) bool {
+	if cert == nil || machineID == "" {
+		return false
+	}
+	if cert.Subject.CommonName == machineID {
+		return true
+	}
+	return slices.Contains(cert.DNSNames, machineID)
+}
+
 // FIXME broken error handling, should also be printed to the session
 func (c *console) sessionHandler(s ssh.Session) {
-	c.log.Info("ssh session handler called", "machineID", s.User())
 	machineID := s.User()
+	c.log.Info("ssh session handler called", "machineID", machineID)
+
+	cert, _ := s.Context().Value(tlsPeerCertContextKey).(*x509.Certificate)
+	if cert == nil {
+		c.log.Warn("refusing session without TLS peer certificate", "machineID", machineID)
+		_, _ = io.WriteString(s, "unauthorized: client certificate required\n")
+		_ = s.Exit(1)
+		return
+	}
+	if !certAuthorizedFor(cert, machineID) {
+		c.log.Warn("unauthorized console access attempt",
+			"machineID", machineID,
+			"cert_subject", cert.Subject.String(),
+			"cert_dns_sans", cert.DNSNames,
+			"cert_serial", cert.SerialNumber.String(),
+		)
+		_, _ = io.WriteString(s, "unauthorized: client certificate not issued for this machine\n")
+		_ = s.Exit(1)
+		return
+	}
+	c.log.Info("authorized console session",
+		"machineID", machineID,
+		"cert_subject", cert.Subject.CommonName,
+		"cert_serial", cert.SerialNumber.String(),
+	)
 
 	resp, err := c.client.Machine().FindIPMIMachine(machine.NewFindIPMIMachineParams().WithID(machineID), nil)
 	if err != nil || resp.Payload == nil || resp.Payload.Ipmi == nil {

--- a/internal/bmc/console_test.go
+++ b/internal/bmc/console_test.go
@@ -1,0 +1,75 @@
+package bmc
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+)
+
+func TestCertAuthorizedFor(t *testing.T) {
+	mkCert := func(cn string, sans ...string) *x509.Certificate {
+		return &x509.Certificate{
+			Subject:   pkix.Name{CommonName: cn},
+			DNSNames:  sans,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		cert      *x509.Certificate
+		machineID string
+		want      bool
+	}{
+		{
+			name:      "CN matches machineID",
+			cert:      mkCert("machine-1"),
+			machineID: "machine-1",
+			want:      true,
+		},
+		{
+			name:      "DNS SAN matches machineID",
+			cert:      mkCert("operator@example", "machine-2", "machine-3"),
+			machineID: "machine-3",
+			want:      true,
+		},
+		{
+			name:      "CN mismatch and no SAN rejects",
+			cert:      mkCert("machine-1"),
+			machineID: "machine-2",
+			want:      false,
+		},
+		{
+			name:      "SAN mismatch rejects",
+			cert:      mkCert("operator@example", "machine-2"),
+			machineID: "machine-1",
+			want:      false,
+		},
+		{
+			name:      "empty machineID never matches",
+			cert:      mkCert("", ""),
+			machineID: "",
+			want:      false,
+		},
+		{
+			name:      "nil cert never matches",
+			cert:      nil,
+			machineID: "machine-1",
+			want:      false,
+		},
+		{
+			name:      "empty CN does not match empty machineID",
+			cert:      mkCert(""),
+			machineID: "",
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := certAuthorizedFor(tc.cert, tc.machineID)
+			if got != tc.want {
+				t.Fatalf("certAuthorizedFor(%+v, %q) = %v, want %v", tc.cert, tc.machineID, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Bind the verified TLS peer certificate to the SSH context via a ConnCallback, and require in sessionHandler that the requested machineID matches the certificate's CN or a DNS SAN before any metal-api call or console attachment. Fail closed on missing cert or mismatch, and log cert subject/serial on every accept or reject for auditing.

#### Used AI-Tools ✨

Generated-By: Claude-Code/Opus 4.7

