### PR TITLE
Allow passing static hosts to BMC reporter.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/google/go-cmp v0.7.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/metal-stack/go-hal v0.7.2
+	github.com/metal-stack/go-hal v0.7.4-0.20260825080049-9d96243845df
 	github.com/metal-stack/metal-go v0.43.1
 	github.com/metal-stack/metal-lib v0.24.1
 	github.com/metal-stack/v v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e h1:Q6MvJtQK/iRcRt
 github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/metal-stack/go-hal v0.7.2 h1:csQK0oHtJGo9jTC8FS4hiE0VjnTxgaZxI/1/vIH2hiE=
-github.com/metal-stack/go-hal v0.7.2/go.mod h1:SiirnwMXjm5IFcXrJj9gKKkCGqmsUmdhRL24YjBIDsw=
+github.com/metal-stack/go-hal v0.7.4-0.20260825080049-9d96243845df h1:dtU9QLNKsZGde6dmiaOGj2COcwo8ivE9S3Wf6KTzxr8=
+github.com/metal-stack/go-hal v0.7.4-0.20260825080049-9d96243845df/go.mod h1:SiirnwMXjm5IFcXrJj9gKKkCGqmsUmdhRL24YjBIDsw=
 github.com/metal-stack/metal-go v0.43.1 h1:pPkABQKbx5FaUFNzHIjSDKTj7jP4vXusEiaRK697EN0=
 github.com/metal-stack/metal-go v0.43.1/go.mod h1:GSfXrAj55LGsUSMHWGDsmq5n056NG0yb1JM8bgfvKOw=
 github.com/metal-stack/metal-lib v0.24.1 h1:hpXEGkIQVQW7FyLCfe2F24Ww/Q/sNBWJ3hfY57OUZMM=

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -21,19 +22,21 @@ import (
 
 // reporter reports information about bmc, bios and dhcp ip of bmc to metal-api
 type reporter struct {
-	cfg    *config.Config
-	log    *slog.Logger
-	client metalgo.Client
-	sem    *semaphore.Weighted
+	cfg         *config.Config
+	log         *slog.Logger
+	client      metalgo.Client
+	sem         *semaphore.Weighted
+	staticHosts []string
 }
 
 // New will create a reporter for MachineIpmiReports
 func New(log *slog.Logger, cfg *config.Config, client metalgo.Client) (*reporter, error) {
 	return &reporter{
-		cfg:    cfg,
-		log:    log,
-		client: client,
-		sem:    semaphore.NewWeighted(1),
+		cfg:         cfg,
+		log:         log,
+		client:      client,
+		sem:         semaphore.NewWeighted(1),
+		staticHosts: cfg.StaticHosts,
 	}, nil
 }
 
@@ -95,6 +98,22 @@ func (r reporter) getReportItems() ([]*leases.ReportItem, error) {
 	ls, err := leases.ReadLeases(r.log, r.cfg.LeaseFile)
 	if err != nil {
 		return nil, err
+	}
+
+	now := time.Now()
+
+	for _, host := range r.staticHosts {
+		mac, ip, ok := strings.Cut(host, ";")
+		if !ok {
+			return nil, fmt.Errorf("invalid static host: %s", ip)
+		}
+
+		ls = append(ls, leases.Lease{
+			Mac:   mac,
+			Ip:    ip,
+			Begin: now.Add(-1 * time.Minute),
+			End:   now.Add(7 * 24 * time.Hour),
+		})
 	}
 
 	if len(ls) == 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"errors"
 	"net/netip"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -21,6 +23,7 @@ type Config struct {
 	IpmiPassword    string        `required:"false" default:"ADMIN" desc:"the ipmi password" split_words:"true"`
 	IgnoreMacs      []string      `required:"false" desc:"mac addresses to ignore" split_words:"true"`
 	AllowedCidrs    []string      `required:"false" default:"0.0.0.0/0" desc:"filters dhcp leases" split_words:"true"`
+	StaticHosts     []string      `required:"false" desc:"a static BMC host list that is used in addition to the addresses discovered from the dhcpd lease list. must be in the form <mac>-<ip>" split_words:"true"`
 
 	// NSQ connection parameters
 	MQAddress           string        `required:"false" default:"localhost:4150" desc:"set the nsqd server address" envconfig:"mq_address"`
@@ -45,5 +48,18 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+
+	for _, host := range c.StaticHosts {
+		_, ip, ok := strings.Cut(host, ";")
+		if !ok {
+			return errors.New("static hosts must be provided in the form <mac>;<ip>")
+		}
+
+		_, err := netip.ParseAddr(ip)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Description

This PR allows configuring static BMC hosts for reporting that do not come from the dhcpd lease file. This allows configuring the ipmi_sim BMCs in the mini-lab, which do not retrieve an IP address from the dhcpd but instead get them from the docker network directly.

I think there was also a similar feature request from @GeertJohan?

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
